### PR TITLE
Fixed incorrect container port and mapped folder within container

### DIFF
--- a/compose-files/dashy/dashy.yml
+++ b/compose-files/dashy/dashy.yml
@@ -5,12 +5,13 @@ services:
     # To build from source, replace 'image: lissy93/dashy' with 'build: .'
     # build: .
     image: lissy93/dashy
-    container_name: Dashy
-    # Pass in your config file below, by specifying the path on your host machine
+    container_name: dashy
+    # conf.yml on host must exist prior to uncommenting the volumes line and data mapping line
+    # basic conf.yml can be found at https://github.com/Lissy93/dashy
     # volumes:
-    # - /root/my-config.yml:/app/public/conf.yml
+    #  - ${PATH_TO_DATA}/dashy/conf.yml:/app/user-data/conf.yml
     ports:
-      - 4000:80
+      - 4000:8080
     # Set any environmental variables
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
- Changed container_name to be lowercase, same as most other omv compose containers

- As omv compose examples are primarily for newcomers, have provided more explanation about uncommenting the volume line and mapping line.

- Changed the mapping line, the host directory isn't in line with other omv compose syntax for data folder. Container directory is the incorrect directory, the conf.yml needs to be in /app/user-data or it does nothing.

- Container port number is incorrect, the container by default listens on 8080, not 80. So it isn't reachable, just another thing newcomers have to troubleshoot for no reason.