### PR TITLE
Update env_file references in komodo.yml to use komodo.env

### DIFF
--- a/compose-files/komodo/komodo.yml
+++ b/compose-files/komodo/komodo.yml
@@ -31,7 +31,6 @@ services:
       - mongo
     ports:
       - 9120:9120
-    env_file: ./komodo.env
     environment:
       KOMODO_DATABASE_ADDRESS: mongo:27017
       KOMODO_DATABASE_USERNAME: ${KOMODO_DB_USERNAME}
@@ -55,7 +54,6 @@ services:
     labels:
       komodo.skip: # Prevent Komodo from stopping with StopAllContainers
     restart: unless-stopped
-    env_file: ./komodo.env
     volumes:
       ## Mount external docker socket
       - /var/run/docker.sock:/var/run/docker.sock

--- a/compose-files/komodo/komodo.yml
+++ b/compose-files/komodo/komodo.yml
@@ -31,7 +31,7 @@ services:
       - mongo
     ports:
       - 9120:9120
-    env_file: ./compose.env
+    env_file: ./komodo.env
     environment:
       KOMODO_DATABASE_ADDRESS: mongo:27017
       KOMODO_DATABASE_USERNAME: ${KOMODO_DB_USERNAME}
@@ -55,7 +55,7 @@ services:
     labels:
       komodo.skip: # Prevent Komodo from stopping with StopAllContainers
     restart: unless-stopped
-    env_file: ./compose.env
+    env_file: ./komodo.env
     volumes:
       ## Mount external docker socket
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
When running `docker compose up -d` for komodo, the following error occurs:

```
env file /compose/komodo/compose.env not found: stat /compose/komodo/compose.env: no such file or directory

*** ERROR #1 ***

END OF LINE
```

This was happening because the yml file was referencing the env file with the wrong filename.