### PR TITLE
Add env_file reference for core and periphery services in komodo.yml

### DIFF
--- a/compose-files/komodo/komodo.yml
+++ b/compose-files/komodo/komodo.yml
@@ -35,6 +35,7 @@ services:
       - mongo
     ports:
       - 9120:9120
+    env_file: ./komodo.env
     environment:
       KOMODO_DATABASE_ADDRESS: mongo:27017
       KOMODO_DATABASE_USERNAME: ${KOMODO_DB_USERNAME}
@@ -58,6 +59,7 @@ services:
     labels:
       komodo.skip: # Prevent Komodo from stopping with StopAllContainers
     restart: unless-stopped
+    env_file: ./komodo.env
     volumes:
       ## Mount external docker socket
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
With the reference to the `env` file, the Komodo core can load those vars.